### PR TITLE
fix(intro doc): update iframe width

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 Lets understand what **Gnars Dao is in less than 5 minutes**.
 
 
-<iframe width="900" height="500" src="https://www.youtube.com/embed/61xVd5wjQ2M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="100%" height="500" src="https://www.youtube.com/embed/61xVd5wjQ2M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Getting Started
 


### PR DESCRIPTION
Adjust the iframe of the documentation introduction so that it doesn't cut off the width in the mobile version

<img width="1792" alt="Captura de Tela 2024-04-04 às 18 15 43" src="https://github.com/gnars-dao/gnars-docs/assets/43586732/9790065d-de32-4482-bfd7-f56c20ebbc81">
